### PR TITLE
Allow to use it with Ecto 3

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -49,7 +49,7 @@ defmodule ComeoninEctoPassword.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:ecto, "~> 2.2"},
+      {:ecto, "~> 3.0"},
       {:comeonin, "~> 4.0"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:pbkdf2_elixir, "~> 0.12", optional: true},


### PR DESCRIPTION
### What?
Hi, nice to meet you. I'm here because I'm trying to use this lib with a Phoenix app that is using `Ecto 3` as dependency and this package is not compatible with Ecto bigger than 2 right.

I just did this initial PR to bump Ecto dependency upto 3. 

I'm sure I'm missing something but this change allowed me to use it in my project. Please let me know what you think?

Thanks for the lib!